### PR TITLE
Add task rename_argument_typescript

### DIFF
--- a/file_editing_bench/add_env_config/config.diff
+++ b/file_editing_bench/add_env_config/config.diff
@@ -5,8 +5,8 @@
 -from typing import Dict, Any
 +from typing import Dict, Any, Optional
  import yaml
-
-
+ 
+ 
 +def get_env_value(
 +    key: str, default: Any = None, required: bool = False
 +) -> Optional[Any]:
@@ -49,4 +49,4 @@
 +            "password": get_env_value("SMTP_PASSWORD", required=True),
          },
      }
-
+ 

--- a/file_editing_bench/rename_argument_typescript/imageProcessor.after.ts
+++ b/file_editing_bench/rename_argument_typescript/imageProcessor.after.ts
@@ -1,0 +1,45 @@
+interface ImageMetadata {
+  width: number;
+  height: number;
+  format: string;
+  dateCreated: Date;
+}
+
+/**
+ * Processes an image and returns metadata about the processed result
+ * @param imageBuffer The buffer containing the raw image data
+ * @param opts Additional processing options
+ */
+export function processImage(imageBuffer: Buffer, opts: {
+  maxWidth?: number;
+  maxHeight?: number;
+  convertTo?: 'jpeg' | 'png' | 'webp';
+  quality?: number;
+}): Promise<ImageMetadata> {
+  // Validate the input buffer
+  if (!imageBuffer || imageBuffer.length === 0) {
+    throw new Error('Invalid image buffer provided');
+  }
+
+  // Apply default options if not provided
+  const finalOpts = {
+    maxWidth: opts.maxWidth || 1920,
+    maxHeight: opts.maxHeight || 1080,
+    convertTo: opts.convertTo || 'jpeg',
+    quality: opts.quality || 80
+  };
+
+  // Here we would process imageBuffer (the image buffer) with the provided options
+  // This is just a mock implementation
+  const mockProcess = async () => {
+    const size = imageBuffer.length;
+    return {
+      width: Math.min(size % 1000, finalOpts.maxWidth),
+      height: Math.min(size % 800, finalOpts.maxHeight),
+      format: finalOpts.convertTo,
+      dateCreated: new Date()
+    };
+  };
+
+  return mockProcess();
+}

--- a/file_editing_bench/rename_argument_typescript/imageProcessor.diff
+++ b/file_editing_bench/rename_argument_typescript/imageProcessor.diff
@@ -1,0 +1,36 @@
+--- a/file_editing_bench/rename_argument_typescript/task_files/imageProcessor.ts
++++ b/file_editing_bench/rename_argument_typescript/imageProcessor.after.ts
+@@ -7,17 +7,17 @@ interface ImageMetadata {
+ 
+ /**
+  * Processes an image and returns metadata about the processed result
+- * @param p The buffer containing the raw image data
++ * @param imageBuffer The buffer containing the raw image data
+  * @param opts Additional processing options
+  */
+-export function processImage(p: Buffer, opts: {
++export function processImage(imageBuffer: Buffer, opts: {
+   maxWidth?: number;
+   maxHeight?: number;
+   convertTo?: 'jpeg' | 'png' | 'webp';
+   quality?: number;
+ }): Promise<ImageMetadata> {
+   // Validate the input buffer
+-  if (!p || p.length === 0) {
++  if (!imageBuffer || imageBuffer.length === 0) {
+     throw new Error('Invalid image buffer provided');
+   }
+ 
+@@ -29,10 +29,10 @@ export function processImage(p: Buffer, opts: {
+     quality: opts.quality || 80
+   };
+ 
+-  // Here we would process p (the image buffer) with the provided options
++  // Here we would process imageBuffer (the image buffer) with the provided options
+   // This is just a mock implementation
+   const mockProcess = async () => {
+-    const size = p.length;
++    const size = imageBuffer.length;
+     return {
+       width: Math.min(size % 1000, finalOpts.maxWidth),
+       height: Math.min(size % 800, finalOpts.maxHeight),

--- a/file_editing_bench/rename_argument_typescript/instructions.md
+++ b/file_editing_bench/rename_argument_typescript/instructions.md
@@ -1,0 +1,10 @@
+# Rename Argument Task
+
+In the file `imageProcessor.ts`, rename the parameter `p` in the `processImage` function to `imageBuffer`. This parameter represents a buffer containing raw image data.
+
+The rename should:
+1. Update the parameter name in the function signature
+2. Update the JSDoc comment that describes the parameter
+3. Update all usages of the parameter within the function body
+
+Make sure to maintain all TypeScript types and function behavior exactly as they were, changing only the parameter name.

--- a/file_editing_bench/rename_argument_typescript/task_files/imageProcessor.ts
+++ b/file_editing_bench/rename_argument_typescript/task_files/imageProcessor.ts
@@ -1,0 +1,45 @@
+interface ImageMetadata {
+  width: number;
+  height: number;
+  format: string;
+  dateCreated: Date;
+}
+
+/**
+ * Processes an image and returns metadata about the processed result
+ * @param p The buffer containing the raw image data
+ * @param opts Additional processing options
+ */
+export function processImage(p: Buffer, opts: {
+  maxWidth?: number;
+  maxHeight?: number;
+  convertTo?: 'jpeg' | 'png' | 'webp';
+  quality?: number;
+}): Promise<ImageMetadata> {
+  // Validate the input buffer
+  if (!p || p.length === 0) {
+    throw new Error('Invalid image buffer provided');
+  }
+
+  // Apply default options if not provided
+  const finalOpts = {
+    maxWidth: opts.maxWidth || 1920,
+    maxHeight: opts.maxHeight || 1080,
+    convertTo: opts.convertTo || 'jpeg',
+    quality: opts.quality || 80
+  };
+
+  // Here we would process p (the image buffer) with the provided options
+  // This is just a mock implementation
+  const mockProcess = async () => {
+    const size = p.length;
+    return {
+      width: Math.min(size % 1000, finalOpts.maxWidth),
+      height: Math.min(size % 800, finalOpts.maxHeight),
+      format: finalOpts.convertTo,
+      dateCreated: new Date()
+    };
+  };
+
+  return mockProcess();
+}


### PR DESCRIPTION
This PR adds a new benchmark task for renaming function arguments in TypeScript.

The task:
- Creates a realistic TypeScript image processing function with a poorly named parameter 'p'
- Requires renaming it to the more descriptive 'imageBuffer'
- Includes updates to JSDoc comments and all parameter usages
- Provides clear instructions and verification files

The benchmark tests the ability to:
1. Identify all locations where a parameter needs to be renamed
2. Maintain correct TypeScript types
3. Update documentation consistently
4. Preserve all existing functionality