### PR TITLE
Add delete_fn_typescript task

### DIFF
--- a/file_editing_bench/delete_fn_typescript/instructions.md
+++ b/file_editing_bench/delete_fn_typescript/instructions.md
@@ -1,0 +1,5 @@
+# Delete Function Task
+
+In the file `userService.ts`, delete the `sendPasswordReset` function and its corresponding import that is no longer used after the function is removed.
+
+Note that the `sendWelcomeEmail` import is still used by the `createUser` function, so it should not be removed.

--- a/file_editing_bench/delete_fn_typescript/task_files/userService.ts
+++ b/file_editing_bench/delete_fn_typescript/task_files/userService.ts
@@ -1,0 +1,42 @@
+import { User } from './types';
+import { validateEmail } from './validation';
+import { hashPassword } from './security';
+import { DatabaseConnection } from './database';
+import { sendWelcomeEmail } from './notifications';
+
+export async function createUser(email: string, password: string): Promise<User> {
+    if (!validateEmail(email)) {
+        throw new Error('Invalid email format');
+    }
+    
+    const hashedPassword = await hashPassword(password);
+    const db = new DatabaseConnection();
+    
+    const user = await db.users.create({
+        email,
+        password: hashedPassword,
+    });
+    
+    await sendWelcomeEmail(user.email);
+    return user;
+}
+
+export async function deleteUser(userId: string): Promise<void> {
+    const db = new DatabaseConnection();
+    await db.users.delete({ id: userId });
+}
+
+export async function sendPasswordReset(email: string): Promise<void> {
+    if (!validateEmail(email)) {
+        throw new Error('Invalid email format');
+    }
+    
+    const db = new DatabaseConnection();
+    const user = await db.users.findOne({ email });
+    
+    if (!user) {
+        throw new Error('User not found');
+    }
+    
+    await sendWelcomeEmail(user.email);
+}

--- a/file_editing_bench/delete_fn_typescript/userService.after.ts
+++ b/file_editing_bench/delete_fn_typescript/userService.after.ts
@@ -1,0 +1,27 @@
+import { User } from './types';
+import { validateEmail } from './validation';
+import { hashPassword } from './security';
+import { DatabaseConnection } from './database';
+import { sendWelcomeEmail } from './notifications';
+
+export async function createUser(email: string, password: string): Promise<User> {
+    if (!validateEmail(email)) {
+        throw new Error('Invalid email format');
+    }
+    
+    const hashedPassword = await hashPassword(password);
+    const db = new DatabaseConnection();
+    
+    const user = await db.users.create({
+        email,
+        password: hashedPassword,
+    });
+    
+    await sendWelcomeEmail(user.email);
+    return user;
+}
+
+export async function deleteUser(userId: string): Promise<void> {
+    const db = new DatabaseConnection();
+    await db.users.delete({ id: userId });
+}

--- a/file_editing_bench/delete_fn_typescript/userService.diff
+++ b/file_editing_bench/delete_fn_typescript/userService.diff
@@ -1,0 +1,23 @@
+--- a/file_editing_bench/delete_fn_typescript/task_files/userService.ts
++++ b/file_editing_bench/delete_fn_typescript/userService.after.ts
+@@ -24,19 +24,4 @@ export async function createUser(email: string, password: string): Promise<User>
+ export async function deleteUser(userId: string): Promise<void> {
+     const db = new DatabaseConnection();
+     await db.users.delete({ id: userId });
+-}
+-
+-export async function sendPasswordReset(email: string): Promise<void> {
+-    if (!validateEmail(email)) {
+-        throw new Error('Invalid email format');
+-    }
+-    
+-    const db = new DatabaseConnection();
+-    const user = await db.users.findOne({ email });
+-    
+-    if (!user) {
+-        throw new Error('User not found');
+-    }
+-    
+-    await sendWelcomeEmail(user.email);
+ }
+\ No newline at end of file


### PR DESCRIPTION
This PR adds a new benchmark task for deleting a function and its corresponding imports in TypeScript.

The task includes:
- A TypeScript file with multiple functions and imports
- Instructions to delete the sendPasswordReset function
- Verification that unused imports are removed
- Complete before/after files and diff

The task tests the ability to:
1. Identify and remove a specific function
2. Clean up related imports
3. Maintain the integrity of remaining code