### PR TITLE
Add inline_fn_typescript task

### DIFF
--- a/file_editing_bench/inline_fn_typescript/instructions.md
+++ b/file_editing_bench/inline_fn_typescript/instructions.md
@@ -1,0 +1,11 @@
+# Inline Function Task
+
+In the file `processUserData.ts`, inline the `validateEmailFormat` helper function directly into the `processUserRegistration` function where it's being called. After inlining, delete the original `validateEmailFormat` function.
+
+The email validation logic should be inserted directly where the `validateEmailFormat()` function is called in the if statement, and the original helper function should be removed entirely.
+
+This task requires:
+1. Moving the email validation logic into the `processUserRegistration` function
+2. Removing the original `validateEmailFormat` function declaration
+3. Maintaining the exact same functionality and validation logic
+4. Keeping all type annotations and interfaces unchanged

--- a/file_editing_bench/inline_fn_typescript/processUserData.after.ts
+++ b/file_editing_bench/inline_fn_typescript/processUserData.after.ts
@@ -1,0 +1,25 @@
+interface UserData {
+    id: number;
+    name: string;
+    email: string;
+    preferences: {
+        theme: 'light' | 'dark';
+        notifications: boolean;
+    };
+}
+
+function processUserRegistration(userData: UserData): { success: boolean; message: string } {
+    if (!userData.name || userData.name.length < 2) {
+        return { success: false, message: 'Name must be at least 2 characters long' };
+    }
+
+    if (!((/^[^\s@]+@[^\s@]+\.[^\s@]+$/).test(userData.email) && userData.email.length <= 255)) {
+        return { success: false, message: 'Invalid email format' };
+    }
+
+    // Process the valid user data
+    return {
+        success: true,
+        message: `User ${userData.name} successfully registered with email ${userData.email}`
+    };
+}

--- a/file_editing_bench/inline_fn_typescript/processUserData.diff
+++ b/file_editing_bench/inline_fn_typescript/processUserData.diff
@@ -1,0 +1,21 @@
+--- a/file_editing_bench/inline_fn_typescript/task_files/processUserData.ts
++++ b/file_editing_bench/inline_fn_typescript/processUserData.after.ts
+@@ -8,17 +8,12 @@ interface UserData {
+     };
+ }
+ 
+-function validateEmailFormat(email: string): boolean {
+-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+-    return emailRegex.test(email) && email.length <= 255;
+-}
+-
+ function processUserRegistration(userData: UserData): { success: boolean; message: string } {
+     if (!userData.name || userData.name.length < 2) {
+         return { success: false, message: 'Name must be at least 2 characters long' };
+     }
+ 
+-    if (!validateEmailFormat(userData.email)) {
++    if (!((/^[^\s@]+@[^\s@]+\.[^\s@]+$/).test(userData.email) && userData.email.length <= 255)) {
+         return { success: false, message: 'Invalid email format' };
+     }
+ 

--- a/file_editing_bench/inline_fn_typescript/task_files/processUserData.ts
+++ b/file_editing_bench/inline_fn_typescript/task_files/processUserData.ts
@@ -1,0 +1,30 @@
+interface UserData {
+    id: number;
+    name: string;
+    email: string;
+    preferences: {
+        theme: 'light' | 'dark';
+        notifications: boolean;
+    };
+}
+
+function validateEmailFormat(email: string): boolean {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email) && email.length <= 255;
+}
+
+function processUserRegistration(userData: UserData): { success: boolean; message: string } {
+    if (!userData.name || userData.name.length < 2) {
+        return { success: false, message: 'Name must be at least 2 characters long' };
+    }
+
+    if (!validateEmailFormat(userData.email)) {
+        return { success: false, message: 'Invalid email format' };
+    }
+
+    // Process the valid user data
+    return {
+        success: true,
+        message: `User ${userData.name} successfully registered with email ${userData.email}`
+    };
+}


### PR DESCRIPTION
This PR adds a new task for inlining a TypeScript function.

The task involves:
- Inlining a helper function (validateEmailFormat) into the main function where it's called
- Removing the original helper function
- Maintaining exact functionality while simplifying the code structure

The task tests the ability to refactor TypeScript code while preserving type safety and functionality.