### PR TITLE
Add task delete_fn_python

### DIFF
--- a/file_editing_bench/delete_fn_python/data_processor.after.py
+++ b/file_editing_bench/delete_fn_python/data_processor.after.py
@@ -1,0 +1,30 @@
+import json
+from datetime import datetime
+from typing import Dict, List, Optional
+import pandas as pd
+
+def load_json_data(filepath: str) -> Dict:
+    """Load data from a JSON file."""
+    with open(filepath, 'r') as f:
+        return json.load(f)
+
+def process_timestamps(data: List[Dict]) -> List[Dict]:
+    """Convert timestamp strings to datetime objects."""
+    for item in data:
+        if 'timestamp' in item:
+            item['timestamp'] = datetime.fromisoformat(item['timestamp'])
+    return data
+
+def calculate_metrics(df: pd.DataFrame) -> Dict[str, float]:
+    """Calculate basic statistical metrics."""
+    return {
+        'mean': df['value'].mean(),
+        'median': df['value'].median(),
+        'std': df['value'].std()
+    }
+
+def export_results(data: Dict[str, float], output_path: Optional[str] = None) -> None:
+    """Export results to JSON file."""
+    output_path = output_path or 'results.json'
+    with open(output_path, 'w') as f:
+        json.dump(data, f, indent=2)

--- a/file_editing_bench/delete_fn_python/data_processor.diff
+++ b/file_editing_bench/delete_fn_python/data_processor.diff
@@ -1,0 +1,22 @@
+--- a/file_editing_bench/delete_fn_python/task_files/data_processor.py
++++ b/file_editing_bench/delete_fn_python/data_processor.after.py
+@@ -1,7 +1,6 @@
+ import json
+ from datetime import datetime
+ from typing import Dict, List, Optional
+-from urllib.parse import urlparse  # This import will need to be removed
+ import pandas as pd
+ 
+ def load_json_data(filepath: str) -> Dict:
+@@ -9,11 +8,6 @@ def load_json_data(filepath: str) -> Dict:
+     with open(filepath, 'r') as f:
+         return json.load(f)
+ 
+-def extract_domain(url: str) -> str:
+-    """Extract domain from URL - this function will be deleted."""
+-    parsed = urlparse(url)
+-    return parsed.netloc
+-
+ def process_timestamps(data: List[Dict]) -> List[Dict]:
+     """Convert timestamp strings to datetime objects."""
+     for item in data:

--- a/file_editing_bench/delete_fn_python/instructions.md
+++ b/file_editing_bench/delete_fn_python/instructions.md
@@ -1,0 +1,9 @@
+# Delete Function Task
+
+Edit the file `data_processor.py` to remove the `extract_domain` function and its corresponding import. Specifically:
+
+1. Delete the function `extract_domain` completely
+2. Remove the import statement `from urllib.parse import urlparse` since it's no longer needed
+3. Keep all other functions and imports intact
+
+The final file should maintain the same formatting and spacing as the original, just without the specified function and import.

--- a/file_editing_bench/delete_fn_python/task_files/data_processor.py
+++ b/file_editing_bench/delete_fn_python/task_files/data_processor.py
@@ -1,0 +1,36 @@
+import json
+from datetime import datetime
+from typing import Dict, List, Optional
+from urllib.parse import urlparse  # This import will need to be removed
+import pandas as pd
+
+def load_json_data(filepath: str) -> Dict:
+    """Load data from a JSON file."""
+    with open(filepath, 'r') as f:
+        return json.load(f)
+
+def extract_domain(url: str) -> str:
+    """Extract domain from URL - this function will be deleted."""
+    parsed = urlparse(url)
+    return parsed.netloc
+
+def process_timestamps(data: List[Dict]) -> List[Dict]:
+    """Convert timestamp strings to datetime objects."""
+    for item in data:
+        if 'timestamp' in item:
+            item['timestamp'] = datetime.fromisoformat(item['timestamp'])
+    return data
+
+def calculate_metrics(df: pd.DataFrame) -> Dict[str, float]:
+    """Calculate basic statistical metrics."""
+    return {
+        'mean': df['value'].mean(),
+        'median': df['value'].median(),
+        'std': df['value'].std()
+    }
+
+def export_results(data: Dict[str, float], output_path: Optional[str] = None) -> None:
+    """Export results to JSON file."""
+    output_path = output_path or 'results.json'
+    with open(output_path, 'w') as f:
+        json.dump(data, f, indent=2)


### PR DESCRIPTION
This PR adds a new benchmark task for deleting a function and its corresponding import from a Python file.

The task includes:
- A Python file with multiple functions and imports
- Instructions to delete the 'extract_domain' function and its corresponding 'urlparse' import
- The expected 'after' state of the file
- Generated diff file showing the expected changes

The task tests the ability to:
1. Identify and remove a specific function
2. Remove the corresponding unused import
3. Maintain proper file formatting and structure