### PR TITLE
Add rename_argument_typescript benchmark

### DIFF
--- a/file_editing_bench/rename_argument_typescript/instructions.md
+++ b/file_editing_bench/rename_argument_typescript/instructions.md
@@ -1,0 +1,9 @@
+# Rename Argument Task
+
+In the file `processUserData.ts`, there is a function `generateUserStatsSummary` that takes two parameters:
+1. `stats: UserStats`
+2. `d: number`
+
+The parameter `d` is used throughout the function to represent the number of days to look back for the analysis. Rename this parameter from `d` to `lookbackDays` to make the code more readable and self-documenting.
+
+Make sure to update all occurrences of this parameter within the function body as well.

--- a/file_editing_bench/rename_argument_typescript/processUserData.after.ts
+++ b/file_editing_bench/rename_argument_typescript/processUserData.after.ts
@@ -1,0 +1,27 @@
+interface UserStats {
+  totalLogins: number;
+  lastLoginDate: Date;
+  accountType: 'free' | 'premium';
+}
+
+/**
+ * Processes user statistics and returns a formatted summary
+ * for administrative purposes.
+ */
+function generateUserStatsSummary(stats: UserStats, lookbackDays: number): string {
+  const daysAgo = new Date();
+  daysAgo.setDate(daysAgo.getDate() - lookbackDays);
+  
+  const isRecentlyActive = stats.lastLoginDate >= daysAgo;
+  const accountStatus = stats.accountType === 'premium' ? 'Premium Member' : 'Free Tier';
+  
+  const activityLevel = 
+    stats.totalLogins > lookbackDays * 2 ? 'High' :
+    stats.totalLogins > lookbackDays ? 'Medium' : 'Low';
+
+  return `User Activity Summary:
+    Account Type: ${accountStatus}
+    Activity Level: ${activityLevel}
+    Recently Active: ${isRecentlyActive ? 'Yes' : 'No'}
+    Login Frequency: ${(stats.totalLogins / lookbackDays).toFixed(2)} logins/day`;
+}

--- a/file_editing_bench/rename_argument_typescript/processUserData.diff
+++ b/file_editing_bench/rename_argument_typescript/processUserData.diff
@@ -1,0 +1,29 @@
+--- a/file_editing_bench/rename_argument_typescript/task_files/processUserData.ts
++++ b/file_editing_bench/rename_argument_typescript/processUserData.after.ts
+@@ -8,20 +8,20 @@ interface UserStats {
+  * Processes user statistics and returns a formatted summary
+  * for administrative purposes.
+  */
+-function generateUserStatsSummary(stats: UserStats, d: number): string {
++function generateUserStatsSummary(stats: UserStats, lookbackDays: number): string {
+   const daysAgo = new Date();
+-  daysAgo.setDate(daysAgo.getDate() - d);
++  daysAgo.setDate(daysAgo.getDate() - lookbackDays);
+   
+   const isRecentlyActive = stats.lastLoginDate >= daysAgo;
+   const accountStatus = stats.accountType === 'premium' ? 'Premium Member' : 'Free Tier';
+   
+   const activityLevel = 
+-    stats.totalLogins > d * 2 ? 'High' :
+-    stats.totalLogins > d ? 'Medium' : 'Low';
++    stats.totalLogins > lookbackDays * 2 ? 'High' :
++    stats.totalLogins > lookbackDays ? 'Medium' : 'Low';
+ 
+   return `User Activity Summary:
+     Account Type: ${accountStatus}
+     Activity Level: ${activityLevel}
+     Recently Active: ${isRecentlyActive ? 'Yes' : 'No'}
+-    Login Frequency: ${(stats.totalLogins / d).toFixed(2)} logins/day`;
++    Login Frequency: ${(stats.totalLogins / lookbackDays).toFixed(2)} logins/day`;
+ }
+\ No newline at end of file

--- a/file_editing_bench/rename_argument_typescript/task_files/processUserData.ts
+++ b/file_editing_bench/rename_argument_typescript/task_files/processUserData.ts
@@ -1,0 +1,27 @@
+interface UserStats {
+  totalLogins: number;
+  lastLoginDate: Date;
+  accountType: 'free' | 'premium';
+}
+
+/**
+ * Processes user statistics and returns a formatted summary
+ * for administrative purposes.
+ */
+function generateUserStatsSummary(stats: UserStats, d: number): string {
+  const daysAgo = new Date();
+  daysAgo.setDate(daysAgo.getDate() - d);
+  
+  const isRecentlyActive = stats.lastLoginDate >= daysAgo;
+  const accountStatus = stats.accountType === 'premium' ? 'Premium Member' : 'Free Tier';
+  
+  const activityLevel = 
+    stats.totalLogins > d * 2 ? 'High' :
+    stats.totalLogins > d ? 'Medium' : 'Low';
+
+  return `User Activity Summary:
+    Account Type: ${accountStatus}
+    Activity Level: ${activityLevel}
+    Recently Active: ${isRecentlyActive ? 'Yes' : 'No'}
+    Login Frequency: ${(stats.totalLogins / d).toFixed(2)} logins/day`;
+}


### PR DESCRIPTION
This PR adds a new benchmark task for renaming function arguments in TypeScript.

The task involves:
- Renaming a poorly named parameter 'd' to 'lookbackDays' in a user statistics processing function
- Updating all usages of the parameter within the function
- Provides clear instructions and verification files

The benchmark tests the ability to perform precise argument renaming while maintaining the functionality of the code.