### PR TITLE
Add task rename_variables_in_fn_go

### DIFF
--- a/file_editing_bench/rename_variables_in_fn_go/instructions.md
+++ b/file_editing_bench/rename_variables_in_fn_go/instructions.md
@@ -1,0 +1,11 @@
+# Rename Variables in Function
+
+In the file `process_orders.go`, rename the following variables inside the `ProcessDailyOrders` function to be more descriptive:
+
+1. Rename variable `t` to `totalRevenue` (it represents the running sum of order amounts)
+2. Rename variable `n` to `orderCount` (it represents the count of orders processed)
+3. Rename variable `f` to `completedOrders` (it represents the slice of completed orders)
+
+Make sure to update all instances where these variables are used within the function.
+
+The variables should be renamed exactly as specified above, maintaining the same types and functionality.

--- a/file_editing_bench/rename_variables_in_fn_go/process_orders.after.go
+++ b/file_editing_bench/rename_variables_in_fn_go/process_orders.after.go
@@ -1,0 +1,34 @@
+package orders
+
+import (
+	"time"
+)
+
+// ProcessDailyOrders calculates total revenue and generates summary statistics
+// for orders processed within the last 24 hours
+func ProcessDailyOrders(orders []Order) (*DailySummary, error) {
+	var totalRevenue float64
+	var orderCount int
+	var completedOrders []*Order
+
+	for _, o := range orders {
+		if time.Since(o.CreatedAt) <= 24*time.Hour {
+			totalRevenue += o.Amount
+			orderCount++
+			if o.Status == "completed" {
+				completedOrders = append(completedOrders, &o)
+			}
+		}
+	}
+
+	if orderCount == 0 {
+		return nil, ErrNoOrders
+	}
+
+	return &DailySummary{
+		TotalRevenue:      totalRevenue,
+		ProcessedOrders:   orderCount,
+		CompletedOrders:   completedOrders,
+		AverageOrderValue: totalRevenue / float64(orderCount),
+	}, nil
+}

--- a/file_editing_bench/rename_variables_in_fn_go/process_orders.diff
+++ b/file_editing_bench/rename_variables_in_fn_go/process_orders.diff
@@ -1,0 +1,43 @@
+--- a/file_editing_bench/rename_variables_in_fn_go/task_files/process_orders.go
++++ b/file_editing_bench/rename_variables_in_fn_go/process_orders.after.go
+@@ -7,28 +7,28 @@ import (
+ // ProcessDailyOrders calculates total revenue and generates summary statistics
+ // for orders processed within the last 24 hours
+ func ProcessDailyOrders(orders []Order) (*DailySummary, error) {
+-	var t float64
+-	var n int
+-	var f []*Order
++	var totalRevenue float64
++	var orderCount int
++	var completedOrders []*Order
+ 
+ 	for _, o := range orders {
+ 		if time.Since(o.CreatedAt) <= 24*time.Hour {
+-			t += o.Amount
+-			n++
++			totalRevenue += o.Amount
++			orderCount++
+ 			if o.Status == "completed" {
+-				f = append(f, &o)
++				completedOrders = append(completedOrders, &o)
+ 			}
+ 		}
+ 	}
+ 
+-	if n == 0 {
++	if orderCount == 0 {
+ 		return nil, ErrNoOrders
+ 	}
+ 
+ 	return &DailySummary{
+-		TotalRevenue:      t,
+-		ProcessedOrders:   n,
+-		CompletedOrders:   f,
+-		AverageOrderValue: t / float64(n),
++		TotalRevenue:      totalRevenue,
++		ProcessedOrders:   orderCount,
++		CompletedOrders:   completedOrders,
++		AverageOrderValue: totalRevenue / float64(orderCount),
+ 	}, nil
+ }
+\ No newline at end of file

--- a/file_editing_bench/rename_variables_in_fn_go/task_files/process_orders.go
+++ b/file_editing_bench/rename_variables_in_fn_go/task_files/process_orders.go
@@ -1,0 +1,34 @@
+package orders
+
+import (
+	"time"
+)
+
+// ProcessDailyOrders calculates total revenue and generates summary statistics
+// for orders processed within the last 24 hours
+func ProcessDailyOrders(orders []Order) (*DailySummary, error) {
+	var t float64
+	var n int
+	var f []*Order
+
+	for _, o := range orders {
+		if time.Since(o.CreatedAt) <= 24*time.Hour {
+			t += o.Amount
+			n++
+			if o.Status == "completed" {
+				f = append(f, &o)
+			}
+		}
+	}
+
+	if n == 0 {
+		return nil, ErrNoOrders
+	}
+
+	return &DailySummary{
+		TotalRevenue:      t,
+		ProcessedOrders:   n,
+		CompletedOrders:   f,
+		AverageOrderValue: t / float64(n),
+	}, nil
+}


### PR DESCRIPTION
This PR adds a new benchmark task for renaming variables in a Go function.

The task involves:
- Renaming three poorly named variables in a ProcessDailyOrders function
- Variables to be renamed: t -> totalRevenue, n -> orderCount, f -> completedOrders
- Includes original file, instructions, and expected output file
- Task tests ability to rename variables while maintaining functionality