### PR TITLE
Add rename_global_variable_ruby task

### DIFF
--- a/file_editing_bench/rename_global_variable_ruby/game_config.after.rb
+++ b/file_editing_bench/rename_global_variable_ruby/game_config.after.rb
@@ -1,0 +1,28 @@
+# Global configuration for the Pixel Adventure game engine
+$display_resolution = {width: 1920, height: 1080}
+
+module GameEngine
+  class Display
+    def self.initialize_screen
+      puts "Initializing display with resolution #{$display_resolution[:width]}x#{$display_resolution[:height]}"
+      @window_size = $display_resolution
+    end
+  end
+
+  class AssetLoader
+    def self.scale_sprites
+      scale_factor = ($display_resolution[:width] / 1920.0)
+      puts "Scaling game assets by factor of #{scale_factor}"
+    end
+  end
+end
+
+# Example usage
+if __FILE__ == $PROGRAM_NAME
+  GameEngine::Display.initialize_screen
+  GameEngine::AssetLoader.scale_sprites
+  
+  # Allow runtime resolution changes
+  $display_resolution = {width: 1280, height: 720}
+  GameEngine::Display.initialize_screen
+end

--- a/file_editing_bench/rename_global_variable_ruby/game_config.diff
+++ b/file_editing_bench/rename_global_variable_ruby/game_config.diff
@@ -1,0 +1,33 @@
+--- a/file_editing_bench/rename_global_variable_ruby/task_files/game_config.rb
++++ b/file_editing_bench/rename_global_variable_ruby/game_config.after.rb
+@@ -1,17 +1,17 @@
+ # Global configuration for the Pixel Adventure game engine
+-$screen_res = {width: 1920, height: 1080}
++$display_resolution = {width: 1920, height: 1080}
+ 
+ module GameEngine
+   class Display
+     def self.initialize_screen
+-      puts "Initializing display with resolution #{$screen_res[:width]}x#{$screen_res[:height]}"
+-      @window_size = $screen_res
++      puts "Initializing display with resolution #{$display_resolution[:width]}x#{$display_resolution[:height]}"
++      @window_size = $display_resolution
+     end
+   end
+ 
+   class AssetLoader
+     def self.scale_sprites
+-      scale_factor = ($screen_res[:width] / 1920.0)
++      scale_factor = ($display_resolution[:width] / 1920.0)
+       puts "Scaling game assets by factor of #{scale_factor}"
+     end
+   end
+@@ -23,6 +23,6 @@ if __FILE__ == $PROGRAM_NAME
+   GameEngine::AssetLoader.scale_sprites
+   
+   # Allow runtime resolution changes
+-  $screen_res = {width: 1280, height: 720}
++  $display_resolution = {width: 1280, height: 720}
+   GameEngine::Display.initialize_screen
+ end
+\ No newline at end of file

--- a/file_editing_bench/rename_global_variable_ruby/instructions.md
+++ b/file_editing_bench/rename_global_variable_ruby/instructions.md
@@ -1,0 +1,10 @@
+# Rename Global Variable
+
+In the file `game_config.rb`, rename the global variable `$screen_res` to `$display_resolution`. This variable represents the screen resolution configuration for the game engine.
+
+The variable should be renamed in all places where it is used, including:
+- The initial declaration
+- All references within the GameEngine module
+- The runtime modification in the example usage section
+
+Make sure to maintain the exact same functionality while only changing the variable name.

--- a/file_editing_bench/rename_global_variable_ruby/task_files/game_config.rb
+++ b/file_editing_bench/rename_global_variable_ruby/task_files/game_config.rb
@@ -1,0 +1,28 @@
+# Global configuration for the Pixel Adventure game engine
+$screen_res = {width: 1920, height: 1080}
+
+module GameEngine
+  class Display
+    def self.initialize_screen
+      puts "Initializing display with resolution #{$screen_res[:width]}x#{$screen_res[:height]}"
+      @window_size = $screen_res
+    end
+  end
+
+  class AssetLoader
+    def self.scale_sprites
+      scale_factor = ($screen_res[:width] / 1920.0)
+      puts "Scaling game assets by factor of #{scale_factor}"
+    end
+  end
+end
+
+# Example usage
+if __FILE__ == $PROGRAM_NAME
+  GameEngine::Display.initialize_screen
+  GameEngine::AssetLoader.scale_sprites
+  
+  # Allow runtime resolution changes
+  $screen_res = {width: 1280, height: 720}
+  GameEngine::Display.initialize_screen
+end


### PR DESCRIPTION
This PR adds a new benchmark task for renaming a global variable in Ruby.

The task:
- Creates a realistic example of a game engine configuration using a global variable
- Requires renaming `$screen_res` to `$display_resolution`
- Tests the ability to consistently rename variables across multiple contexts
- Includes clear instructions and verification files

The benchmark verifies that:
- All instances of the global variable are renamed
- Code functionality remains unchanged
- Proper Ruby syntax is maintained