### PR TITLE
Add task: rename variables in Rust function

### DIFF
--- a/file_editing_bench/rename_variables_in_fn_rust/instructions.md
+++ b/file_editing_bench/rename_variables_in_fn_rust/instructions.md
@@ -1,0 +1,11 @@
+# Rename Variables in Function
+
+In the file `process_data.rs`, improve the readability of the `analyze_server_metrics` function by renaming the following variables to be more descriptive:
+
+1. Rename parameter `x` to `metrics_values`
+2. Rename parameter `m` to `metric_indices`
+3. Rename parameter `t` to `threshold`
+
+Make sure to update all occurrences of these variables within the function body. The function signature and logic should remain exactly the same, only the variable names should change.
+
+Note: Do not modify any other variables or the `calculate_weight` function.

--- a/file_editing_bench/rename_variables_in_fn_rust/process_data.after.rs
+++ b/file_editing_bench/rename_variables_in_fn_rust/process_data.after.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+pub fn analyze_server_metrics(metrics_values: Vec<i32>, metric_indices: HashMap<String, i32>, threshold: i32) -> f64 {
+    let mut s = 0;
+    
+    // Calculate sum of all values above threshold
+    for n in metrics_values.iter() {
+        if *n > threshold {
+            s += n;
+        }
+    }
+
+    // Apply weights from the mapping
+    let mut r = 0.0;
+    for (k, v) in metric_indices.iter() {
+        if let Some(n) = metrics_values.get(*v as usize) {
+            r += *n as f64 * calculate_weight(k);
+        }
+    }
+
+    // Return weighted average
+    if s > 0 {
+        r / s as f64
+    } else {
+        0.0
+    }
+}
+
+fn calculate_weight(metric_name: &str) -> f64 {
+    match metric_name {
+        "cpu" => 2.0,
+        "memory" => 1.5,
+        _ => 1.0,
+    }
+}

--- a/file_editing_bench/rename_variables_in_fn_rust/process_data.diff
+++ b/file_editing_bench/rename_variables_in_fn_rust/process_data.diff
@@ -1,0 +1,27 @@
+--- a/file_editing_bench/rename_variables_in_fn_rust/task_files/process_data.rs
++++ b/file_editing_bench/rename_variables_in_fn_rust/process_data.after.rs
+@@ -1,19 +1,19 @@
+ use std::collections::HashMap;
+ 
+-pub fn analyze_server_metrics(x: Vec<i32>, m: HashMap<String, i32>, t: i32) -> f64 {
++pub fn analyze_server_metrics(metrics_values: Vec<i32>, metric_indices: HashMap<String, i32>, threshold: i32) -> f64 {
+     let mut s = 0;
+     
+     // Calculate sum of all values above threshold
+-    for n in x.iter() {
+-        if *n > t {
++    for n in metrics_values.iter() {
++        if *n > threshold {
+             s += n;
+         }
+     }
+ 
+     // Apply weights from the mapping
+     let mut r = 0.0;
+-    for (k, v) in m.iter() {
+-        if let Some(n) = x.get(*v as usize) {
++    for (k, v) in metric_indices.iter() {
++        if let Some(n) = metrics_values.get(*v as usize) {
+             r += *n as f64 * calculate_weight(k);
+         }
+     }

--- a/file_editing_bench/rename_variables_in_fn_rust/task_files/process_data.rs
+++ b/file_editing_bench/rename_variables_in_fn_rust/task_files/process_data.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+pub fn analyze_server_metrics(x: Vec<i32>, m: HashMap<String, i32>, t: i32) -> f64 {
+    let mut s = 0;
+    
+    // Calculate sum of all values above threshold
+    for n in x.iter() {
+        if *n > t {
+            s += n;
+        }
+    }
+
+    // Apply weights from the mapping
+    let mut r = 0.0;
+    for (k, v) in m.iter() {
+        if let Some(n) = x.get(*v as usize) {
+            r += *n as f64 * calculate_weight(k);
+        }
+    }
+
+    // Return weighted average
+    if s > 0 {
+        r / s as f64
+    } else {
+        0.0
+    }
+}
+
+fn calculate_weight(metric_name: &str) -> f64 {
+    match metric_name {
+        "cpu" => 2.0,
+        "memory" => 1.5,
+        _ => 1.0,
+    }
+}


### PR DESCRIPTION
This PR adds a new benchmark task for renaming variables in a Rust function.

The task involves:
- Renaming three poorly named variables in a server metrics analysis function
- Variables to be renamed: x -> metrics_values, m -> metric_indices, t -> threshold
- Includes original file, instructions, and expected output
- Provides a realistic example of Rust code that might be found in a production environment

The task tests the ability to:
1. Identify variables that need to be renamed
2. Consistently update all occurrences of the variables
3. Maintain the exact same functionality while improving code readability