### PR TITLE
Add task rename_class_typescript

### DIFF
--- a/file_editing_bench/rename_class_typescript/analytics.after.ts
+++ b/file_editing_bench/rename_class_typescript/analytics.after.ts
@@ -1,0 +1,69 @@
+import { Database } from './types';
+
+interface MetricPayload {
+  name: string;
+  value: number;
+  timestamp: number;
+  tags?: Record<string, string>;
+}
+
+// Helper class for data validation
+class ValidationUtils {
+  static isValidMetricName(name: string): boolean {
+    return /^[a-zA-Z][a-zA-Z0-9_\.]*$/.test(name);
+  }
+
+  static isValidTimestamp(timestamp: number): boolean {
+    return timestamp > 0 && timestamp <= Date.now();
+  }
+}
+
+// This class processes and batches metrics
+class MetricBatchProcessor {
+  private db: Database;
+  private readonly batchSize: number = 100;
+  private metricQueue: MetricPayload[] = [];
+  
+  constructor(db: Database, batchSize?: number) {
+    this.db = db;
+    if (batchSize) this.batchSize = batchSize;
+  }
+
+  async addMetric(metric: MetricPayload): Promise<void> {
+    if (!ValidationUtils.isValidMetricName(metric.name)) {
+      throw new Error('Invalid metric name');
+    }
+    if (!ValidationUtils.isValidTimestamp(metric.timestamp)) {
+      throw new Error('Invalid timestamp');
+    }
+
+    this.metricQueue.push(metric);
+    
+    if (this.metricQueue.length >= this.batchSize) {
+      await this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.metricQueue.length === 0) return;
+
+    const metrics = [...this.metricQueue];
+    this.metricQueue = [];
+    
+    await this.db.batchInsert('metrics', metrics);
+  }
+
+  getQueueSize(): number {
+    return this.metricQueue.length;
+  }
+}
+
+// Analytics dashboard configuration
+class DashboardConfig {
+  constructor(
+    public readonly refreshInterval: number = 60000,
+    public readonly defaultTimeRange: string = '24h'
+  ) {}
+}
+
+export { MetricBatchProcessor, ValidationUtils, DashboardConfig, MetricPayload };

--- a/file_editing_bench/rename_class_typescript/analytics.diff
+++ b/file_editing_bench/rename_class_typescript/analytics.diff
@@ -1,0 +1,21 @@
+--- a/file_editing_bench/rename_class_typescript/task_files/analytics.ts
++++ b/file_editing_bench/rename_class_typescript/analytics.after.ts
+@@ -18,8 +18,8 @@ class ValidationUtils {
+   }
+ }
+ 
+-// This class needs a more descriptive name
+-class Proc {
++// This class processes and batches metrics
++class MetricBatchProcessor {
+   private db: Database;
+   private readonly batchSize: number = 100;
+   private metricQueue: MetricPayload[] = [];
+@@ -66,4 +66,4 @@ class DashboardConfig {
+   ) {}
+ }
+ 
+-export { Proc, ValidationUtils, DashboardConfig, MetricPayload };
+\ No newline at end of file
++export { MetricBatchProcessor, ValidationUtils, DashboardConfig, MetricPayload };
+\ No newline at end of file

--- a/file_editing_bench/rename_class_typescript/instructions.md
+++ b/file_editing_bench/rename_class_typescript/instructions.md
@@ -1,0 +1,11 @@
+# Rename Class Task
+
+In the file `analytics.ts`, there is a class named `Proc` that processes and batches metrics before sending them to a database. The name `Proc` is not descriptive enough and should be renamed to `MetricBatchProcessor` to better reflect its purpose and functionality.
+
+## Task
+
+Rename the class `Proc` to `MetricBatchProcessor`. Make sure to:
+1. Update the class declaration
+2. Update the export statement at the bottom of the file
+
+The functionality and implementation of the class should remain exactly the same.

--- a/file_editing_bench/rename_class_typescript/task_files/analytics.ts
+++ b/file_editing_bench/rename_class_typescript/task_files/analytics.ts
@@ -1,0 +1,69 @@
+import { Database } from './types';
+
+interface MetricPayload {
+  name: string;
+  value: number;
+  timestamp: number;
+  tags?: Record<string, string>;
+}
+
+// Helper class for data validation
+class ValidationUtils {
+  static isValidMetricName(name: string): boolean {
+    return /^[a-zA-Z][a-zA-Z0-9_\.]*$/.test(name);
+  }
+
+  static isValidTimestamp(timestamp: number): boolean {
+    return timestamp > 0 && timestamp <= Date.now();
+  }
+}
+
+// This class needs a more descriptive name
+class Proc {
+  private db: Database;
+  private readonly batchSize: number = 100;
+  private metricQueue: MetricPayload[] = [];
+  
+  constructor(db: Database, batchSize?: number) {
+    this.db = db;
+    if (batchSize) this.batchSize = batchSize;
+  }
+
+  async addMetric(metric: MetricPayload): Promise<void> {
+    if (!ValidationUtils.isValidMetricName(metric.name)) {
+      throw new Error('Invalid metric name');
+    }
+    if (!ValidationUtils.isValidTimestamp(metric.timestamp)) {
+      throw new Error('Invalid timestamp');
+    }
+
+    this.metricQueue.push(metric);
+    
+    if (this.metricQueue.length >= this.batchSize) {
+      await this.flush();
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.metricQueue.length === 0) return;
+
+    const metrics = [...this.metricQueue];
+    this.metricQueue = [];
+    
+    await this.db.batchInsert('metrics', metrics);
+  }
+
+  getQueueSize(): number {
+    return this.metricQueue.length;
+  }
+}
+
+// Analytics dashboard configuration
+class DashboardConfig {
+  constructor(
+    public readonly refreshInterval: number = 60000,
+    public readonly defaultTimeRange: string = '24h'
+  ) {}
+}
+
+export { Proc, ValidationUtils, DashboardConfig, MetricPayload };


### PR DESCRIPTION
This PR adds a new benchmark task for renaming a TypeScript class.

The task involves:
- Renaming a class from a non-descriptive name 'Proc' to a more descriptive 'MetricBatchProcessor'
- The class handles metric processing and batching for analytics
- The task tests the ability to properly rename a class and update all related references
- Includes clear instructions and verification files