### PR TITLE
Add task delete_fn_python

### DIFF
--- a/file_editing_bench/add_env_config/config.diff
+++ b/file_editing_bench/add_env_config/config.diff
@@ -5,8 +5,8 @@
 -from typing import Dict, Any
 +from typing import Dict, Any, Optional
  import yaml
-
-
+ 
+ 
 +def get_env_value(
 +    key: str, default: Any = None, required: bool = False
 +) -> Optional[Any]:
@@ -49,4 +49,4 @@
 +            "password": get_env_value("SMTP_PASSWORD", required=True),
          },
      }
-
+ 

--- a/file_editing_bench/delete_fn_python/data_processor.after.py
+++ b/file_editing_bench/delete_fn_python/data_processor.after.py
@@ -1,30 +1,35 @@
 import json
 from datetime import datetime
 from typing import Dict, List, Optional
-import pandas as pd
+from urllib.parse import urlparse
+from pathlib import Path
 
-def load_json_data(filepath: str) -> Dict:
-    """Load data from a JSON file."""
-    with open(filepath, 'r') as f:
+def load_config(config_path: str) -> Dict:
+    """Load configuration from a JSON file."""
+    with open(config_path) as f:
         return json.load(f)
 
-def process_timestamps(data: List[Dict]) -> List[Dict]:
-    """Convert timestamp strings to datetime objects."""
-    for item in data:
-        if 'timestamp' in item:
-            item['timestamp'] = datetime.fromisoformat(item['timestamp'])
-    return data
-
-def calculate_metrics(df: pd.DataFrame) -> Dict[str, float]:
-    """Calculate basic statistical metrics."""
+def parse_url_components(url: str) -> Dict[str, str]:
+    """Extract components from a URL."""
+    parsed = urlparse(url)
     return {
-        'mean': df['value'].mean(),
-        'median': df['value'].median(),
-        'std': df['value'].std()
+        "scheme": parsed.scheme,
+        "netloc": parsed.netloc,
+        "path": parsed.path,
+        "params": parsed.params,
+        "query": parsed.query,
+        "fragment": parsed.fragment
     }
 
-def export_results(data: Dict[str, float], output_path: Optional[str] = None) -> None:
-    """Export results to JSON file."""
-    output_path = output_path or 'results.json'
-    with open(output_path, 'w') as f:
-        json.dump(data, f, indent=2)
+def format_timestamp(dt: datetime) -> str:
+    """Format a datetime object into a standardized string."""
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+def process_log_files(log_dir: str) -> List[Dict]:
+    """Process all log files in a directory."""
+    results = []
+    log_path = Path(log_dir)
+    for file in log_path.glob("*.log"):
+        with open(file) as f:
+            results.extend(json.loads(line) for line in f)
+    return results

--- a/file_editing_bench/delete_fn_python/data_processor.diff
+++ b/file_editing_bench/delete_fn_python/data_processor.diff
@@ -1,22 +1,26 @@
 --- a/file_editing_bench/delete_fn_python/task_files/data_processor.py
 +++ b/file_editing_bench/delete_fn_python/data_processor.after.py
-@@ -1,7 +1,6 @@
- import json
+@@ -2,7 +2,6 @@ import json
  from datetime import datetime
  from typing import Dict, List, Optional
--from urllib.parse import urlparse  # This import will need to be removed
- import pandas as pd
+ from urllib.parse import urlparse
+-import requests
+ from pathlib import Path
  
- def load_json_data(filepath: str) -> Dict:
-@@ -9,11 +8,6 @@ def load_json_data(filepath: str) -> Dict:
-     with open(filepath, 'r') as f:
-         return json.load(f)
+ def load_config(config_path: str) -> Dict:
+@@ -22,15 +21,6 @@ def parse_url_components(url: str) -> Dict[str, str]:
+         "fragment": parsed.fragment
+     }
  
--def extract_domain(url: str) -> str:
--    """Extract domain from URL - this function will be deleted."""
--    parsed = urlparse(url)
--    return parsed.netloc
+-def fetch_remote_data(endpoint: str) -> Optional[Dict]:
+-    """Fetch data from a remote endpoint using requests."""
+-    try:
+-        response = requests.get(endpoint, timeout=10)
+-        response.raise_for_status()
+-        return response.json()
+-    except requests.RequestException:
+-        return None
 -
- def process_timestamps(data: List[Dict]) -> List[Dict]:
-     """Convert timestamp strings to datetime objects."""
-     for item in data:
+ def format_timestamp(dt: datetime) -> str:
+     """Format a datetime object into a standardized string."""
+     return dt.strftime("%Y-%m-%d %H:%M:%S UTC")

--- a/file_editing_bench/delete_fn_python/instructions.md
+++ b/file_editing_bench/delete_fn_python/instructions.md
@@ -1,9 +1,7 @@
 # Delete Function Task
 
-Edit the file `data_processor.py` to remove the `extract_domain` function and its corresponding import. Specifically:
+Your task is to modify the `data_processor.py` file by:
+1. Removing the `fetch_remote_data` function completely
+2. Removing the corresponding `requests` import since it's no longer needed
 
-1. Delete the function `extract_domain` completely
-2. Remove the import statement `from urllib.parse import urlparse` since it's no longer needed
-3. Keep all other functions and imports intact
-
-The final file should maintain the same formatting and spacing as the original, just without the specified function and import.
+The rest of the file should remain exactly the same, maintaining all other functions and imports.

--- a/file_editing_bench/delete_fn_python/task_files/data_processor.py
+++ b/file_editing_bench/delete_fn_python/task_files/data_processor.py
@@ -1,36 +1,45 @@
 import json
 from datetime import datetime
 from typing import Dict, List, Optional
-from urllib.parse import urlparse  # This import will need to be removed
-import pandas as pd
+from urllib.parse import urlparse
+import requests
+from pathlib import Path
 
-def load_json_data(filepath: str) -> Dict:
-    """Load data from a JSON file."""
-    with open(filepath, 'r') as f:
+def load_config(config_path: str) -> Dict:
+    """Load configuration from a JSON file."""
+    with open(config_path) as f:
         return json.load(f)
 
-def extract_domain(url: str) -> str:
-    """Extract domain from URL - this function will be deleted."""
+def parse_url_components(url: str) -> Dict[str, str]:
+    """Extract components from a URL."""
     parsed = urlparse(url)
-    return parsed.netloc
-
-def process_timestamps(data: List[Dict]) -> List[Dict]:
-    """Convert timestamp strings to datetime objects."""
-    for item in data:
-        if 'timestamp' in item:
-            item['timestamp'] = datetime.fromisoformat(item['timestamp'])
-    return data
-
-def calculate_metrics(df: pd.DataFrame) -> Dict[str, float]:
-    """Calculate basic statistical metrics."""
     return {
-        'mean': df['value'].mean(),
-        'median': df['value'].median(),
-        'std': df['value'].std()
+        "scheme": parsed.scheme,
+        "netloc": parsed.netloc,
+        "path": parsed.path,
+        "params": parsed.params,
+        "query": parsed.query,
+        "fragment": parsed.fragment
     }
 
-def export_results(data: Dict[str, float], output_path: Optional[str] = None) -> None:
-    """Export results to JSON file."""
-    output_path = output_path or 'results.json'
-    with open(output_path, 'w') as f:
-        json.dump(data, f, indent=2)
+def fetch_remote_data(endpoint: str) -> Optional[Dict]:
+    """Fetch data from a remote endpoint using requests."""
+    try:
+        response = requests.get(endpoint, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException:
+        return None
+
+def format_timestamp(dt: datetime) -> str:
+    """Format a datetime object into a standardized string."""
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+def process_log_files(log_dir: str) -> List[Dict]:
+    """Process all log files in a directory."""
+    results = []
+    log_path = Path(log_dir)
+    for file in log_path.glob("*.log"):
+        with open(file) as f:
+            results.extend(json.loads(line) for line in f)
+    return results


### PR DESCRIPTION
This PR adds a new benchmark task for deleting a function and its corresponding import from a Python file.

The task involves:
- Removing the fetch_remote_data function
- Removing the corresponding requests import
- Maintaining all other functions and imports

The benchmark includes:
- Original task file with realistic Python code
- Clear instructions
- Expected 'after' state
- Generated diff file