### PR TITLE
Add task rename_variables_in_fn_go

### DIFF
--- a/file_editing_bench/rename_variables_across_fn_python/instructions.md
+++ b/file_editing_bench/rename_variables_across_fn_python/instructions.md
@@ -1,0 +1,9 @@
+# Variable Renaming Task
+
+In the file `student_processor.py`, there are several non-descriptive variable names that need to be renamed to be more meaningful. Specifically:
+
+1. The parameter `i` in the `calculate_grade` function should be renamed to `score` since it represents a student's numerical score
+2. The variable `d` in `load_student_data`, `get_class_statistics`, and `calculate_passing_rate` functions should be renamed to `students` since it represents a list of student records
+3. The variable `i` in all loop iterations (in `load_student_data`, `get_class_statistics`, and `calculate_passing_rate` functions) should be renamed to `student` since each iteration deals with a single student record
+
+Make sure to rename all occurrences of these variables consistently throughout the file while preserving the functionality of the code.

--- a/file_editing_bench/rename_variables_across_fn_python/student_processor.after.py
+++ b/file_editing_bench/rename_variables_across_fn_python/student_processor.after.py
@@ -1,0 +1,50 @@
+def load_student_data(lst):
+    students = []
+    for student in lst:
+        if isinstance(student, dict):
+            students.append({
+                'name': student.get('name'),
+                'score': student.get('score', 0),
+                'grade': calculate_grade(student.get('score', 0))
+            })
+    return students
+
+def calculate_grade(score):
+    if score >= 90:
+        return 'A'
+    elif score >= 80:
+        return 'B'
+    elif score >= 70:
+        return 'C'
+    elif score >= 60:
+        return 'D'
+    else:
+        return 'F'
+
+def get_class_statistics(students):
+    if not students:
+        return None
+    
+    total = 0
+    count = len(students)
+    
+    for student in students:
+        total += student.get('score', 0)
+    
+    avg = total / count if count > 0 else 0
+    return {
+        'average': avg,
+        'total_students': count,
+        'passing_rate': calculate_passing_rate(students)
+    }
+
+def calculate_passing_rate(students):
+    if not students:
+        return 0.0
+    
+    passing = 0
+    for student in students:
+        if student.get('score', 0) >= 60:
+            passing += 1
+    
+    return (passing / len(students)) * 100

--- a/file_editing_bench/rename_variables_across_fn_python/student_processor.diff
+++ b/file_editing_bench/rename_variables_across_fn_python/student_processor.diff
@@ -1,0 +1,79 @@
+--- a/file_editing_bench/rename_variables_across_fn_python/task_files/student_processor.py
++++ b/file_editing_bench/rename_variables_across_fn_python/student_processor.after.py
+@@ -1,50 +1,50 @@
+ def load_student_data(lst):
+-    d = []
+-    for i in lst:
+-        if isinstance(i, dict):
+-            d.append({
+-                'name': i.get('name'),
+-                'score': i.get('score', 0),
+-                'grade': calculate_grade(i.get('score', 0))
++    students = []
++    for student in lst:
++        if isinstance(student, dict):
++            students.append({
++                'name': student.get('name'),
++                'score': student.get('score', 0),
++                'grade': calculate_grade(student.get('score', 0))
+             })
+-    return d
++    return students
+ 
+-def calculate_grade(i):
+-    if i >= 90:
++def calculate_grade(score):
++    if score >= 90:
+         return 'A'
+-    elif i >= 80:
++    elif score >= 80:
+         return 'B'
+-    elif i >= 70:
++    elif score >= 70:
+         return 'C'
+-    elif i >= 60:
++    elif score >= 60:
+         return 'D'
+     else:
+         return 'F'
+ 
+-def get_class_statistics(d):
+-    if not d:
++def get_class_statistics(students):
++    if not students:
+         return None
+     
+     total = 0
+-    count = len(d)
++    count = len(students)
+     
+-    for i in d:
+-        total += i.get('score', 0)
++    for student in students:
++        total += student.get('score', 0)
+     
+     avg = total / count if count > 0 else 0
+     return {
+         'average': avg,
+         'total_students': count,
+-        'passing_rate': calculate_passing_rate(d)
++        'passing_rate': calculate_passing_rate(students)
+     }
+ 
+-def calculate_passing_rate(d):
+-    if not d:
++def calculate_passing_rate(students):
++    if not students:
+         return 0.0
+     
+     passing = 0
+-    for i in d:
+-        if i.get('score', 0) >= 60:
++    for student in students:
++        if student.get('score', 0) >= 60:
+             passing += 1
+     
+-    return (passing / len(d)) * 100
+\ No newline at end of file
++    return (passing / len(students)) * 100
+\ No newline at end of file

--- a/file_editing_bench/rename_variables_across_fn_python/task_files/student_processor.py
+++ b/file_editing_bench/rename_variables_across_fn_python/task_files/student_processor.py
@@ -1,0 +1,50 @@
+def load_student_data(lst):
+    d = []
+    for i in lst:
+        if isinstance(i, dict):
+            d.append({
+                'name': i.get('name'),
+                'score': i.get('score', 0),
+                'grade': calculate_grade(i.get('score', 0))
+            })
+    return d
+
+def calculate_grade(i):
+    if i >= 90:
+        return 'A'
+    elif i >= 80:
+        return 'B'
+    elif i >= 70:
+        return 'C'
+    elif i >= 60:
+        return 'D'
+    else:
+        return 'F'
+
+def get_class_statistics(d):
+    if not d:
+        return None
+    
+    total = 0
+    count = len(d)
+    
+    for i in d:
+        total += i.get('score', 0)
+    
+    avg = total / count if count > 0 else 0
+    return {
+        'average': avg,
+        'total_students': count,
+        'passing_rate': calculate_passing_rate(d)
+    }
+
+def calculate_passing_rate(d):
+    if not d:
+        return 0.0
+    
+    passing = 0
+    for i in d:
+        if i.get('score', 0) >= 60:
+            passing += 1
+    
+    return (passing / len(d)) * 100

--- a/file_editing_bench/rename_variables_across_fn_ruby/instructions.md
+++ b/file_editing_bench/rename_variables_across_fn_ruby/instructions.md
@@ -1,0 +1,10 @@
+# Variable Renaming Task
+
+In the file `order_processor.rb`, there is a variable `d` (both as instance variable `@d` and local variable `d`) that is used across multiple functions to track discounts. This variable name is not descriptive enough.
+
+Your task is to rename all instances of this variable (both the instance variable `@d` and the local variable `d`) to `discount_amount` to better reflect its purpose and improve code readability.
+
+Make sure to:
+1. Rename the instance variable `@d` to `@discount_amount`
+2. Rename all local variables `d` to `discount_amount`
+3. Maintain the exact same functionality while only changing the variable names

--- a/file_editing_bench/rename_variables_across_fn_ruby/order_processor.after.rb
+++ b/file_editing_bench/rename_variables_across_fn_ruby/order_processor.after.rb
@@ -1,0 +1,36 @@
+class OrderProcessor
+  def initialize
+    @discount_amount = 0
+  end
+
+  def process_order(items)
+    items.each do |item|
+      @discount_amount += calculate_item_discount(item)
+    end
+    
+    apply_final_adjustments
+  end
+
+  def calculate_item_discount(item)
+    if item.on_sale?
+      discount_amount = item.price * 0.1
+      record_discount(discount_amount)
+      discount_amount
+    else
+      0
+    end
+  end
+
+  def apply_final_adjustments
+    if @discount_amount > 100
+      @discount_amount = 100
+    end
+    @discount_amount
+  end
+
+  private
+
+  def record_discount(discount_amount)
+    puts "Recording discount of #{discount_amount}"
+  end
+end

--- a/file_editing_bench/rename_variables_across_fn_ruby/order_processor.diff
+++ b/file_editing_bench/rename_variables_across_fn_ruby/order_processor.diff
@@ -1,0 +1,50 @@
+--- a/file_editing_bench/rename_variables_across_fn_ruby/task_files/order_processor.rb
++++ b/file_editing_bench/rename_variables_across_fn_ruby/order_processor.after.rb
+@@ -1,11 +1,11 @@
+ class OrderProcessor
+   def initialize
+-    @d = 0
++    @discount_amount = 0
+   end
+ 
+   def process_order(items)
+     items.each do |item|
+-      @d += calculate_item_discount(item)
++      @discount_amount += calculate_item_discount(item)
+     end
+     
+     apply_final_adjustments
+@@ -13,24 +13,24 @@ class OrderProcessor
+ 
+   def calculate_item_discount(item)
+     if item.on_sale?
+-      d = item.price * 0.1
+-      record_discount(d)
+-      d
++      discount_amount = item.price * 0.1
++      record_discount(discount_amount)
++      discount_amount
+     else
+       0
+     end
+   end
+ 
+   def apply_final_adjustments
+-    if @d > 100
+-      @d = 100
++    if @discount_amount > 100
++      @discount_amount = 100
+     end
+-    @d
++    @discount_amount
+   end
+ 
+   private
+ 
+-  def record_discount(d)
+-    puts "Recording discount of #{d}"
++  def record_discount(discount_amount)
++    puts "Recording discount of #{discount_amount}"
+   end
+ end
+\ No newline at end of file

--- a/file_editing_bench/rename_variables_across_fn_ruby/task_files/order_processor.rb
+++ b/file_editing_bench/rename_variables_across_fn_ruby/task_files/order_processor.rb
@@ -1,0 +1,36 @@
+class OrderProcessor
+  def initialize
+    @d = 0
+  end
+
+  def process_order(items)
+    items.each do |item|
+      @d += calculate_item_discount(item)
+    end
+    
+    apply_final_adjustments
+  end
+
+  def calculate_item_discount(item)
+    if item.on_sale?
+      d = item.price * 0.1
+      record_discount(d)
+      d
+    else
+      0
+    end
+  end
+
+  def apply_final_adjustments
+    if @d > 100
+      @d = 100
+    end
+    @d
+  end
+
+  private
+
+  def record_discount(d)
+    puts "Recording discount of #{d}"
+  end
+end

--- a/file_editing_bench/rename_variables_in_fn_go/instructions.md
+++ b/file_editing_bench/rename_variables_in_fn_go/instructions.md
@@ -1,11 +1,9 @@
-# Rename Variables in Function
+# Variable Renaming Task
 
-In the file `process_orders.go`, rename the following variables inside the `ProcessDailyOrders` function to be more descriptive:
+In the file `process_orders.go`, rename the following three variables inside the `ProcessDailyOrders` function to be more descriptive:
 
-1. Rename variable `t` to `totalRevenue` (it represents the running sum of order amounts)
-2. Rename variable `n` to `orderCount` (it represents the count of orders processed)
-3. Rename variable `f` to `completedOrders` (it represents the slice of completed orders)
+1. Rename the variable `t` to `totalRevenue`
+2. Rename the variable `n` to `orderCount`
+3. Rename the variable `f` to `completedOrders`
 
-Make sure to update all instances where these variables are used within the function.
-
-The variables should be renamed exactly as specified above, maintaining the same types and functionality.
+Make sure to update all instances where these variables are used within the function. The function signature and return statement should reflect these changes where applicable.

--- a/file_editing_bench/rename_variables_in_fn_go/process_orders.after.go
+++ b/file_editing_bench/rename_variables_in_fn_go/process_orders.after.go
@@ -4,31 +4,27 @@ import (
 	"time"
 )
 
-// ProcessDailyOrders calculates total revenue and generates summary statistics
-// for orders processed within the last 24 hours
-func ProcessDailyOrders(orders []Order) (*DailySummary, error) {
+type Order struct {
+	ID        int64
+	Total     float64
+	CreatedAt time.Time
+	Status    string
+}
+
+func ProcessDailyOrders(o []Order) (float64, int, error) {
 	var totalRevenue float64
 	var orderCount int
-	var completedOrders []*Order
+	var completedOrders []Order
 
-	for _, o := range orders {
-		if time.Since(o.CreatedAt) <= 24*time.Hour {
-			totalRevenue += o.Amount
-			orderCount++
-			if o.Status == "completed" {
-				completedOrders = append(completedOrders, &o)
+	for _, v := range o {
+		if v.CreatedAt.After(time.Now().Add(-24 * time.Hour)) {
+			if v.Status == "completed" {
+				totalRevenue += v.Total
+				orderCount++
+				completedOrders = append(completedOrders, v)
 			}
 		}
 	}
 
-	if orderCount == 0 {
-		return nil, ErrNoOrders
-	}
-
-	return &DailySummary{
-		TotalRevenue:      totalRevenue,
-		ProcessedOrders:   orderCount,
-		CompletedOrders:   completedOrders,
-		AverageOrderValue: totalRevenue / float64(orderCount),
-	}, nil
+	return totalRevenue, orderCount, nil
 }

--- a/file_editing_bench/rename_variables_in_fn_go/process_orders.diff
+++ b/file_editing_bench/rename_variables_in_fn_go/process_orders.diff
@@ -1,43 +1,30 @@
 --- a/file_editing_bench/rename_variables_in_fn_go/task_files/process_orders.go
 +++ b/file_editing_bench/rename_variables_in_fn_go/process_orders.after.go
-@@ -7,28 +7,28 @@ import (
- // ProcessDailyOrders calculates total revenue and generates summary statistics
- // for orders processed within the last 24 hours
- func ProcessDailyOrders(orders []Order) (*DailySummary, error) {
+@@ -12,19 +12,19 @@ type Order struct {
+ }
+ 
+ func ProcessDailyOrders(o []Order) (float64, int, error) {
 -	var t float64
 -	var n int
--	var f []*Order
+-	var f []Order
 +	var totalRevenue float64
 +	var orderCount int
-+	var completedOrders []*Order
++	var completedOrders []Order
  
- 	for _, o := range orders {
- 		if time.Since(o.CreatedAt) <= 24*time.Hour {
--			t += o.Amount
--			n++
-+			totalRevenue += o.Amount
-+			orderCount++
- 			if o.Status == "completed" {
--				f = append(f, &o)
-+				completedOrders = append(completedOrders, &o)
+ 	for _, v := range o {
+ 		if v.CreatedAt.After(time.Now().Add(-24 * time.Hour)) {
+ 			if v.Status == "completed" {
+-				t += v.Total
+-				n++
+-				f = append(f, v)
++				totalRevenue += v.Total
++				orderCount++
++				completedOrders = append(completedOrders, v)
  			}
  		}
  	}
  
--	if n == 0 {
-+	if orderCount == 0 {
- 		return nil, ErrNoOrders
- 	}
- 
- 	return &DailySummary{
--		TotalRevenue:      t,
--		ProcessedOrders:   n,
--		CompletedOrders:   f,
--		AverageOrderValue: t / float64(n),
-+		TotalRevenue:      totalRevenue,
-+		ProcessedOrders:   orderCount,
-+		CompletedOrders:   completedOrders,
-+		AverageOrderValue: totalRevenue / float64(orderCount),
- 	}, nil
+-	return t, n, nil
++	return totalRevenue, orderCount, nil
  }
 \ No newline at end of file

--- a/file_editing_bench/rename_variables_in_fn_go/task_files/process_orders.go
+++ b/file_editing_bench/rename_variables_in_fn_go/task_files/process_orders.go
@@ -4,31 +4,27 @@ import (
 	"time"
 )
 
-// ProcessDailyOrders calculates total revenue and generates summary statistics
-// for orders processed within the last 24 hours
-func ProcessDailyOrders(orders []Order) (*DailySummary, error) {
+type Order struct {
+	ID        int64
+	Total     float64
+	CreatedAt time.Time
+	Status    string
+}
+
+func ProcessDailyOrders(o []Order) (float64, int, error) {
 	var t float64
 	var n int
-	var f []*Order
+	var f []Order
 
-	for _, o := range orders {
-		if time.Since(o.CreatedAt) <= 24*time.Hour {
-			t += o.Amount
-			n++
-			if o.Status == "completed" {
-				f = append(f, &o)
+	for _, v := range o {
+		if v.CreatedAt.After(time.Now().Add(-24 * time.Hour)) {
+			if v.Status == "completed" {
+				t += v.Total
+				n++
+				f = append(f, v)
 			}
 		}
 	}
 
-	if n == 0 {
-		return nil, ErrNoOrders
-	}
-
-	return &DailySummary{
-		TotalRevenue:      t,
-		ProcessedOrders:   n,
-		CompletedOrders:   f,
-		AverageOrderValue: t / float64(n),
-	}, nil
+	return t, n, nil
 }


### PR DESCRIPTION
This PR adds a new benchmark task for renaming variables within a Go function.

The task requires:
- Renaming three variables in a ProcessDailyOrders function to be more descriptive
- Variables to be renamed: 't' -> 'totalRevenue', 'n' -> 'orderCount', 'f' -> 'completedOrders'
- The task uses a realistic example of processing orders within a 24-hour window

The benchmark includes:
- Original source file with poorly named variables
- Clear instructions for the specific variables to be renamed
- Expected output file showing the correct variable names
- Generated diff file showing the exact changes required