### PR TITLE
Add task rename_argument_python

### DIFF
--- a/file_editing_bench/rename_argument_python/instructions.md
+++ b/file_editing_bench/rename_argument_python/instructions.md
@@ -1,0 +1,1 @@
+In the file `weather_processor.py`, rename the parameter `d` in the `process_weather_data` function to `weather_entries` to better reflect that it represents a list of weather station entries. Update all usages of the parameter within the function accordingly.

--- a/file_editing_bench/rename_argument_python/task_files/weather_processor.py
+++ b/file_editing_bench/rename_argument_python/task_files/weather_processor.py
@@ -1,0 +1,19 @@
+def process_weather_data(d, temp_threshold, include_precipitation=False):
+    """Process weather station data and identify significant weather events."""
+    processed_data = []
+    
+    for entry in d:
+        if entry['temperature'] > temp_threshold:
+            event = {
+                'timestamp': entry['timestamp'],
+                'station_id': entry['station_id'],
+                'event_type': 'high_temperature',
+                'value': entry['temperature']
+            }
+            
+            if include_precipitation and entry.get('precipitation', 0) > 0:
+                event['precipitation_mm'] = entry['precipitation']
+            
+            processed_data.append(event)
+    
+    return processed_data

--- a/file_editing_bench/rename_argument_python/weather_processor.after.py
+++ b/file_editing_bench/rename_argument_python/weather_processor.after.py
@@ -1,0 +1,19 @@
+def process_weather_data(weather_entries, temp_threshold, include_precipitation=False):
+    """Process weather station data and identify significant weather events."""
+    processed_data = []
+    
+    for entry in weather_entries:
+        if entry['temperature'] > temp_threshold:
+            event = {
+                'timestamp': entry['timestamp'],
+                'station_id': entry['station_id'],
+                'event_type': 'high_temperature',
+                'value': entry['temperature']
+            }
+            
+            if include_precipitation and entry.get('precipitation', 0) > 0:
+                event['precipitation_mm'] = entry['precipitation']
+            
+            processed_data.append(event)
+    
+    return processed_data

--- a/file_editing_bench/rename_argument_python/weather_processor.diff
+++ b/file_editing_bench/rename_argument_python/weather_processor.diff
@@ -1,0 +1,13 @@
+--- a/file_editing_bench/rename_argument_python/task_files/weather_processor.py
++++ b/file_editing_bench/rename_argument_python/weather_processor.after.py
+@@ -1,8 +1,8 @@
+-def process_weather_data(d, temp_threshold, include_precipitation=False):
++def process_weather_data(weather_entries, temp_threshold, include_precipitation=False):
+     """Process weather station data and identify significant weather events."""
+     processed_data = []
+     
+-    for entry in d:
++    for entry in weather_entries:
+         if entry['temperature'] > temp_threshold:
+             event = {
+                 'timestamp': entry['timestamp'],


### PR DESCRIPTION
This PR adds a new benchmark task for renaming function arguments in Python.

The task involves:
- Renaming a parameter 'd' to 'weather_entries' in a weather data processing function
- The change makes the code more readable by using a descriptive parameter name
- Includes both the original file and the expected result after the rename
- Provides clear instructions for the task

The benchmark tests the ability to:
1. Identify the parameter to be renamed
2. Rename the parameter consistently
3. Update all usages of the parameter within the function